### PR TITLE
[KYC-2106] 데모 체험하기에 테스트기능 추가

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -63,6 +63,30 @@
   background-color: #373eff;
   border: none;
 }
+.customer--radio-box {
+  border: 1px solid #ced1d2;
+  box-sizing: border-box;
+  border-radius: 8px;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  padding: 14px 20px;
+}
+.customer--radio-check {
+  width: 16px;
+  height: 16px;
+  /* background: #f7f7f7; */
+  border: 1.2px solid #ced1d2;
+  box-sizing: border-box;
+  border-radius: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.customer--radio-check.checked {
+  background-color: #373eff;
+  border: none;
+}
 .customer--title {
   font-family: Noto Sans KR;
   font-style: normal;

--- a/img/circle.svg
+++ b/img/circle.svg
@@ -1,0 +1,4 @@
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="9" height="8" viewBox="0 0 9 8" fill="none"  xml:space="preserve">
+<circle cx="5" cy="4" r="4" fill="white" />
+</svg>

--- a/js/kyc.js
+++ b/js/kyc.js
@@ -1,6 +1,6 @@
 // const KYC_TARGET_ORIGIN = "*";     // 보안적으로 취약하니 *을 사용하는것은 권장하지 않습니다. (refer : https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#:~:text=serialize%20them%20yourself.-,targetOrigin,-Specifies%20what%20the)
-const KYC_TARGET_ORIGIN = "https://kyc.useb.co.kr";
-const KYC_URL = "https://kyc.useb.co.kr/auth";
+const KYC_TARGET_ORIGIN = "https://kyc-dev.useb.co.kr";
+const KYC_URL = "https://kyc-dev.useb.co.kr/auth";
 
 // 고객사별 params 정보는 별도로 전달됩니다. 테스트를 위한 임시계정 정보이며, 운영을 위한 계정정보로 변경 필요
 // 계정정보는 하드코딩하지 않고 적절한 보안수준을 적용하여 관리 필요 (적절한 인증절차 후 내부 Server로 부터 받아오도록 관리 등)
@@ -144,9 +144,9 @@ function initKYC() {
 
     const selectedValue = document.getElementById('userinfo_type').value;
     if (selectedValue === 'param') {
-        document.querySelector('#param .customer--select-check').classList.add('checked');
+        paramBox.click();
     } else {
-        document.querySelector('#use_input_ui .customer--select-check').classList.add('checked');
+        useInputUiBox.click();
     }
 }
 

--- a/js/kyc.js
+++ b/js/kyc.js
@@ -1,6 +1,6 @@
 // const KYC_TARGET_ORIGIN = "*";     // 보안적으로 취약하니 *을 사용하는것은 권장하지 않습니다. (refer : https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#:~:text=serialize%20them%20yourself.-,targetOrigin,-Specifies%20what%20the)
-const KYC_TARGET_ORIGIN = "https://kyc-dev.useb.co.kr";
-const KYC_URL = "https://kyc-dev.useb.co.kr/auth";
+const KYC_TARGET_ORIGIN = "https://kyc.useb.co.kr";
+const KYC_URL = "https://kyc.useb.co.kr/auth";
 
 // 고객사별 params 정보는 별도로 전달됩니다. 테스트를 위한 임시계정 정보이며, 운영을 위한 계정정보로 변경 필요
 // 계정정보는 하드코딩하지 않고 적절한 보안수준을 적용하여 관리 필요 (적절한 인증절차 후 내부 Server로 부터 받아오도록 관리 등)

--- a/js/test.js
+++ b/js/test.js
@@ -1,0 +1,184 @@
+
+function UserException(msg) {
+    this.message = msg;
+    this.name = 'UserException';
+}
+
+function Tester() {
+
+    this.testOnLoad = () => {
+        let resp;
+        try {
+            resp = this.__parseParams();
+
+            if (resp) {
+                if (resp?.params?.userinfo_type === "params") {
+                    // ui control
+                    paramBox.click();
+
+                    // param set
+                    document.getElementById('userinfo_name').value = resp.params.name;
+                    document.getElementById('userinfo_birthday').value = resp.params.birthday;
+                    document.getElementById('userinfo_phone_number').value = resp.params.phone_number;
+                    document.getElementById('userinfo_email').value = resp.params.email;
+                } else if (resp?.params?.userinfo_type === "use_input_ui"){
+                    useInputUiBox.click();
+                } else {
+                    throw UserException("Invalid userinfo_type\n\n" + resp?.params);
+                }
+
+                if (resp?.params?.access_token) {
+                    // ui control
+                    document.getElementById('customerinfo_credential_type_div').style.display = 'none';
+                    document.getElementById('customerinfo_access_token_div').style.display = 'inline-block';
+
+                    // param set
+                    document.getElementById('customerinfo_access_token').value = resp.params.access_token;
+                } else if (resp?.params?.customer_id){
+                    // ui control
+                    document.getElementById('customerinfo_credential_type_div').style.display = 'inline-block';
+                    document.getElementById('customerinfo_access_token_div').style.display = 'none';
+
+                    // param set
+                    document.getElementById('customerinfo_customer_id').value = resp.params.customer_id;
+                    if (resp?.params?.id && resp?.params?.key) {
+                        document.getElementById('customerinfo_id').value = resp.params.id;
+                        document.getElementById('customerinfo_key').value = resp.params.key;
+                    } else {
+                        alert("[Warning] 연결 계정 정보를 입력후 테스트를 시작해주세요.");
+                        document.getElementById("customerinfo_id").focus();
+                    }
+                } else {
+                    throw UserException("Invalid cridential or access_token\n\n" + resp?.params);
+                }
+
+                this.encodedParams = resp?.encodedParams;
+                this.params = resp?.params;
+            }
+        } catch (e) {
+            alert("[ERROR] " + e.message);
+            console.error(e.message);
+        }
+    }
+
+    this.testStartBtnOnClick = () => {
+        try {
+            if (!!this?.params?.access_token) {
+                // update credential info "id(client_id), key(client_secret)"
+                this.params.id = document.getElementById('customerinfo_access_token').value;
+            } else if (!!this?.params?.customer_id) {
+                // update credential info "id(client_id), key(client_secret)"
+                this.params.id = document.getElementById('customerinfo_id').value;
+                this.params.key = document.getElementById('customerinfo_key').value
+
+                if (!this.__validateCredentialInfo(this.params)) {
+                    throw new UserException("Invalid Credential Info ['customer_id' and 'id' and 'key']\n\n"
+                        + JSON.stringify(this.params));
+                }
+            }
+
+            this.kycIframe = document.getElementById("kyc_iframe");
+            const __this__ = this;
+
+            this.kycIframe.onload = function () {
+                __this__.kycIframe.contentWindow.postMessage(__this__.encodedParams, KYC_TARGET_ORIGIN);
+                hideLoadingUI();
+                startKYC();
+                __this__.onload = null;
+            };
+
+            this.kycIframe.src = KYC_URL;
+            showLoadingUI();
+
+        } catch (e) {
+            alert("[ERROR] " + e.message);
+            console.error(e.message);
+        }
+    }
+
+    this.__paramsToObject = (entries) => {
+        const result = {}
+        for(const [key, value] of entries) { // each 'entry' is a [key, value] tupple
+            result[key] = value;
+        }
+        return result;
+    }
+
+    this.__parseParams = () => {
+        let errorMsg, encodedParams, params;
+
+        const searchParams = new URLSearchParams(location.search);
+
+        const encoded = searchParams.get("encoded") === "true";
+
+        if (encoded) {
+            encodedParams = searchParams.get("encodedParams");
+            params = this.__decodeParams(encodedParams)
+        } else {
+            params = this.__paramsToObject(searchParams.entries());
+            encodedParams = btoa(encodeURIComponent(JSON.stringify(params)));
+        }
+
+        if (!this.__validateUIType(params)) {
+            errorMsg ="[ERROR] Invalid userinfo_type ['params' or 'use_input_ui']\n\n" + JSON.stringify(params);
+            throw new UserException(errorMsg);
+        }
+
+        if (!this.__validateAccessInfo(params)) {
+            errorMsg = "[ERROR] Invalid Access Info ['access_token' or 'customer_id']\n\n" + JSON.stringify(params);
+            throw new UserException(errorMsg);
+        }
+
+        if (!this.__validateParamsDetail(params)) {
+            errorMsg = "[ERROR] Invalid params!\n\n" + JSON.stringify(params);
+            throw new UserException(errorMsg);
+        }
+
+        return {encodedParams: encodedParams, params: params};
+    }
+
+    this.__decodeParams = (encodedParams) => {
+        return JSON.parse(decodeURIComponent(atob(encodedParams)));
+    }
+
+    this.__validateAccessInfo = (params) => {
+        return !!params.access_token || !!params.customer_id;
+    }
+
+    this.__validateCredentialInfo = (params) => {
+        return !!params.customer_id && !!params.id && !!params.key;
+    }
+
+    this.__validateUIType = (params) => {
+        return (params.userinfo_type === "params") || (params.userinfo_type === "use_input_ui");
+    }
+
+    this.__validateParamsDetail = (params) => {
+        let valid = true;
+
+        if (params.userinfo_type === "params") {
+            valid = !!params.name && !!params.birthday && !!params.phone_number && !!params.email;
+        } else if (params.userinfo_type === "use_input_ui") {
+            // nothing to do
+        } else {
+            throw new UserException("Unknown Error");
+        }
+
+        return valid;
+    }
+}
+
+function initTest() {
+    window.tester = new Tester();
+    window.tester.testOnLoad();
+}
+
+function startTest() {
+    window.tester.testStartBtnOnClick();
+}
+
+/** exam **
+ * credential : https://127.0.0.1:8000/test.html?customer_id=9&id=demoUser&key=demoUser0000!&userinfo_type=params&name=%EC%96%91%EB%8F%99%ED%98%84&birthday=1984-11-23&phone_number=01012345678&email=dh.yang@useb.co.kr
+ * access_token : https://127.0.0.1:8000/test.html?access_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NjEzMjE4NzMsIm9yaWdfaWF0IjoxNjYxMjM1NDczLCJwYXlsb2FkIjp7ImN1c3RvbWVyX2lkIjo5LCJjdXN0b21lcl9uYW1lIjoiKHBhcmFtKSBpZCIsImluZHVzdHJ5IjoyLCJpZCI6MywidXNlcm5hbWUiOiJkZW1vVXNlciIsInJvbGUiOjJ9fQ.LnbsTpd0ZfbVk1oRCqrlq4uBX2-eiYhWmv6brp8asFocH7qFVNpjqRGBXdV_X7R1gZg-eqMvlncEswk5ljAEDpNLEXsmKp5G-zzUebB3bHjIutVALySR0csLPzR9_QW-JMTtPLqO6CTfbiDE3XM5eIlzompAo20lLMTvbUgQOJweePZqmpB6BKE7IW-VaKnlh5gO7F1SbkzWn_33rau589_HPSzYXiqqxuG_upjb7qmnrzRg-NX5BqX0PrVdZu1qD256wVyxD4AwUxSOXEbh5-47dV9ibFQpDZS4WxAchOnQGnH9gUq058lUAtx9yBb-WHcZFNfs5nlr0FccyCCoiA&userinfo_type=params&name=%EC%96%91%EB%8F%99%ED%98%84&birthday=1984-11-23&phone_number=01012345678&email=rozig@nate.com
+ */
+

--- a/js/ui_handler.js
+++ b/js/ui_handler.js
@@ -16,15 +16,15 @@ changeEvent.initEvent("change", true, false);
 // })
 
 paramBox.addEventListener('click', () => {
-    document.querySelector('#param .customer--select-check').classList.add('checked');
-    document.querySelector('#use_input_ui .customer--select-check').classList.remove('checked');
+    document.querySelector('#param .customer--radio-check').classList.add('checked');
+    document.querySelector('#use_input_ui .customer--radio-check').classList.remove('checked');
     userinfoTypeSelect.options[0].selected = true;
     userinfoTypeSelect.dispatchEvent(changeEvent);
     userinfoDivision.style.display = 'block'
 });
 useInputUiBox.addEventListener('click', () => {
-    document.querySelector('#use_input_ui .customer--select-check').classList.add('checked');
-    document.querySelector('#param .customer--select-check').classList.remove('checked');
+    document.querySelector('#use_input_ui .customer--radio-check').classList.add('checked');
+    document.querySelector('#param .customer--radio-check').classList.remove('checked');
     userinfoTypeSelect.options[1].selected = true;
     userinfoTypeSelect.dispatchEvent(changeEvent);
     userinfoDivision.style.display = 'none';

--- a/test.html
+++ b/test.html
@@ -9,10 +9,11 @@
     <title>eKYC Sample</title>
     <script type="text/javascript" src="./js/util.js?ver=1.0.19"></script>
     <script type="text/javascript" src="./js/kyc.js?ver=1.0.19"></script>
+    <script type="text/javascript" src="./js/test.js?ver=1.0.19"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"></script>
   </head>
 
-  <body onload="initKYC()">
+  <body onload="initTest(); initKYC();">
     <div id="debug_win" class="debug_win" style="display: none"></div>
     <div
       id="customer_start_ui"
@@ -39,7 +40,6 @@
       </div>
 
       <div class="customer--division"></div>
-
 
       <div class="customer--section">
         <h3 class="customer--headline">개인정보 옵션</h3>
@@ -81,6 +81,7 @@
           입력 UI 제공(사용자 정보 입력 처리를 useb.eKYC에 위임)
         </option>
       </select>
+
       <div class="customer--division" id="userinfo-division"></div>
 
       <div id="userinfo_div" class="customer--section">
@@ -130,7 +131,7 @@
           />
         </div>
         <br />
-        <div class="flex flex-col text-start" style="margin-bottom: 75px">
+        <div class="flex flex-col text-start">
           <span class="customer--label" style="margin-bottom: 8px">
             이메일
           </span>
@@ -141,78 +142,88 @@
             class="customer--input"
           />
         </div>
-        <!-- <button id="userinfo--btn" class="customer--btn">
-          사용자 정보 입력 완료
-        </button> -->
-      </div>
-      <div class="customer--division"></div>
-
-      <div class="customer--section" id="logic-options">
-        <h3 class="customer--headline">기능 선택 옵션</h3>
-        <ul>
-          <li>
-            <img
-              onclick="buttonOnClick(2);"
-              src="img\id.svg"
-              class="imgBtn"
-            /><br />
-          </li>
-          <li>
-            <img
-              onclick="buttonOnClick(3);"
-              src="img\id_face.svg"
-              class="imgBtn"
-            /><br />
-          </li>
-          <li>
-            <img
-              onclick="buttonOnClick(4);"
-              src="img\id_face_live.svg"
-              class="imgBtn"
-            /><br />
-          </li>
-          <li>
-            <img
-              onclick="buttonOnClick(5);"
-              src="img\id_face_live_account.svg"
-              class="imgBtn"
-            /><br />
-          </li>
-          <li>
-            <img
-              onclick="buttonOnClick(6);"
-              src="img\account.svg"
-              class="imgBtn"
-            /><br />
-          </li>
-          <li>
-            <img
-              onclick="buttonOnClick(7);"
-              src="img\id_account.svg"
-              class="imgBtn"
-            /><br />
-          </li>
-          <li>
-            <img
-              onclick="buttonOnClick(8);"
-              src="img\id_face_account.svg"
-              class="imgBtn"
-            /><br />
-          </li>
-        </ul>
       </div>
 
       <div class="customer--division"></div>
 
-      <div class="customer--section">
-        <h3 class="customer--headline">이메일로 홍보중인 체험하기 링크 주소</h3>
-        <button
-          class="customer--btn"
-          onclick="window.location.href='https://kyc.useb.co.kr/auth?token=eyJjdXN0b21lcl9pZCI6ICIxIiwgImlkIjogInVzZXIwMDAxIiwgImtleSI6ICJBbGNoZXJhMDAwMCEifQ%3D%3D';"
-        >
-          체험하기 링크
+      <h3 class="customer--headline">고객사 연결정보</h3>
+
+      <div id="customerinfo_credential_type_div" class="customer--section">
+        <h3 class="customer--title" style="font-size: 20px; margin-top: 0px">
+          credentical 방식
+        </h3>
+        <h6 class="customer--label" style="font-size: 14px; line-height: 24px">
+          client_id, client_secret을 올바로 입력하세요.
+          customer_id는 자동으로 가져옵니다.
+        </h6>
+
+        <div class="flex flex-col text-start">
+          <span class="customer--label" style="margin-bottom: 8px">
+            customer_id
+          </span>
+          <input
+            id="customerinfo_customer_id"
+            type="number"
+            disabled
+            class="input_txt_kr customer--input"
+          />
+        </div>
+        <br />
+        <div class="flex flex-col text-start">
+          <span class="customer--label" style="margin-bottom: 8px">
+            id (client_id)
+          </span>
+          <input
+            id="customerinfo_id"
+            type="text"
+            placeholder="demoUser"
+            class="input_txt_kr customer--input"
+          />
+        </div>
+        <br />
+        <div class="flex flex-col text-start">
+          <span class="customer--label" style="margin-bottom: 8px">
+            key (client_secret)
+          </span>
+          <input
+            id="customerinfo_key"
+            type="text"
+            placeholder="demoUser0000!"
+            class="customer--input"
+          />
+        </div>
+      </div>
+
+      <div id="customerinfo_access_token_div" class="customer--section">
+        <h3 class="customer--title" style="font-size: 20px; margin-top: 0px">
+          access_token 방식
+        </h3>
+        <h6 class="customer--label" style="font-size: 14px; line-height: 24px">
+          access_token 값을 올바로 입력하세요.
+        </h6>
+
+        <div class="flex flex-col text-start" style="margin-bottom: 75px">
+          <span class="customer--label" style="margin-bottom: 8px">
+            access_token
+          </span>
+          <input
+            id="customerinfo_access_token"
+            type="text"
+            placeholder="ACCESS_TOKEN을 입력하세요"
+            class="customer--input"
+          />
+        </div>
+      </div>
+      <div class="customer--division"></div>
+
+      <div id="test_start_div" class="customer--section">
+        <button id="test_start_btn" class="customer--btn" onclick="startTest();">
+          테스트 시작
         </button>
+        <br />
+        <br />
       </div>
+
       <br />
       <br />
     </div>


### PR DESCRIPTION
- queryString으로 전달받은 정보 기준으로 Auth(kyc-user) 기능을 테스트 할 수 있도도록 기능 추가
- 예시
  . credential : https://127.0.0.1:8000/test.html?customer_id=9&id=demoUser&key=demoUser0000!&userinfo_type=params&name=%EC%96%91%EB%8F%99%ED%98%84&birthday=1984-11-23&phone_number=01012345678&email=dh.yang@useb.co.kr
  . access_token : https://127.0.0.1:8000/test.html?access_token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NjEzMjE4NzMsIm9yaWdfaWF0IjoxNjYxMjM1NDczLCJwYXlsb2FkIjp7ImN1c3RvbWVyX2lkIjo5LCJjdXN0b21lcl9uYW1lIjoiKHBhcmFtKSBpZCIsImluZHVzdHJ5IjoyLCJpZCI6MywidXNlcm5hbWUiOiJkZW1vVXNlciIsInJvbGUiOjJ9fQ.LnbsTpd0ZfbVk1oRCqrlq4uBX2-eiYhWmv6brp8asFocH7qFVNpjqRGBXdV_X7R1gZg-eqMvlncEswk5ljAEDpNLEXsmKp5G-zzUebB3bHjIutVALySR0csLPzR9_QW-JMTtPLqO6CTfbiDE3XM5eIlzompAo20lLMTvbUgQOJweePZqmpB6BKE7IW-VaKnlh5gO7F1SbkzWn_33rau589_HPSzYXiqqxuG_upjb7qmnrzRg-NX5BqX0PrVdZu1qD256wVyxD4AwUxSOXEbh5-47dV9ibFQpDZS4WxAchOnQGnH9gUq058lUAtx9yBb-WHcZFNfs5nlr0FccyCCoiA&userinfo_type=params&name=%EC%96%91%EB%8F%99%ED%98%84&birthday=1984-11-23&phone_number=01012345678&email=rozig@nate.com

덤)
- 개인정보 옵션에서 체크박스 ui -> 라디오 ui로 변경

TO-DO)
- Root > 고객사 관리 > 특정고객사에서 "테스트" 버튼 누르면 https://kyc-demo.useb.co.kr/test.html?queryString 으로 테스트 가능하도록 붙이기
  . 2~15번(데모전용) 고객사 연결계정은 demoUser / demoUser0000! 으로 credential 정보를 넣어줄수 있지만, 다른 고객사들은 어떻게하지?? (고민)